### PR TITLE
TASK: Make create-changelog.sh use new commit subject style

### DIFF
--- a/Build/create-changelog.sh
+++ b/Build/create-changelog.sh
@@ -101,8 +101,8 @@ perl -p -i -0 -e 's/(\* [^\n]+)\n+(\* [^\n]+)/$1\n$2/g' ${TARGET}
 git add ${TARGET}
 if [ -z "$BUILD_URL" ]
 then
-	git commit -m "[TASK] Add changelog for ${VERSION}" || echo " nothing to commit "
+	git commit -m "TASK: Add changelog for ${VERSION}" || echo " nothing to commit "
 else
-	git commit -m "[TASK] Add changelog for ${VERSION}" -m "See $BUILD_URL" || echo " nothing to commit "
+	git commit -m "TASK: Add changelog for ${VERSION}" -m "See $BUILD_URL" || echo " nothing to commit "
 fi
 cd -


### PR DESCRIPTION
Instead of '[TASK]' it now uses 'TASK:'