### PR TITLE
TASK: Relax version constraint for Flow

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
         "neos/neos-development-collection": "2.3.x-dev",
-        "neos/flow-development-collection": "3.3.x-dev",
+        "neos/flow-development-collection": "@dev",
         "neos/demo": "2.3.x-dev",
 
         "typo3/party": "@dev",


### PR DESCRIPTION
The stability flag is enough, since Neos itself specifies the correct branch.