### PR TITLE
TASK: No longer require PhpUnit 4.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "flowpack/neos-frontendlogin": "@dev",
         "neos/buildessentials": "4.0.x-dev",
         "mikey179/vfsstream": "~1.6",
-        "phpunit/phpunit": "~4.8 || ~5.4.0",
+        "phpunit/phpunit": "~5.4.0",
         "symfony/css-selector": "~2.0",
         "neos/behat": "dev-master"
     },


### PR DESCRIPTION
It does not work with the required PHP 7 anyway.