### PR TITLE
BUGFIX: Make sure neos/demo dev-master is checked out

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "neos/neos-development-collection": "@dev",
         "neos/flow-development-collection": "@dev",
-        "neos/demo": "@dev",
+        "neos/demo": "dev-master",
 
         "neos/neos-ui": "@dev",
         "neos/neos-ui-compiled": "@dev",


### PR DESCRIPTION
Make sure dev-master is checked out instead of old dev-* branches.

Cloning the neos-development-distribution led to composer checking out the old branch 'dev-fix-deprecation-inject-settings' wich uses non-existing classes instead of the dev-master branch because it is the first one in alphabetical order