### PR TITLE
TASK: Set up crowdin integration (again)

### DIFF
--- a/Build/install-composer.sh
+++ b/Build/install-composer.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# see https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md
+
+EXPECTED_SIGNATURE=$(curl -q https://composer.github.io/installer.sig)
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_SIGNATURE=$(php -r "echo hash_file('SHA384', 'composer-setup.php');")
+
+if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]
+then
+    >&2 echo 'ERROR: Invalid installer signature'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --quiet
+RESULT=$?
+rm composer-setup.php
+exit $RESULT

--- a/Build/sync-crowdin.sh
+++ b/Build/sync-crowdin.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+#
+# This uploads XLIFF sources (english) to and downloads translations from Crowdin
+#
+
+set -e
+
+if [ -z "${CROWDIN_API_KEY}" ]
+then
+  echo "No CROWDIN_API_KEY set.";
+  exit 1;
+fi
+
+if [ ! -e "composer.phar" ]; then
+    Build/install-composer.sh
+fi
+
+# we have this on crowdin as well, install it
+php composer.phar require --prefer-source --no-interaction --no-progress --no-suggest neos/googleanalytics '@dev'
+
+# update packages
+php composer.phar update --no-interaction --no-progress --no-suggest
+
+# run Crowdin scripts
+php Build/BuildEssentials/Crowdin/Setup.php `pwd`/crowdin.json
+php Build/BuildEssentials/Crowdin/Upload.php `pwd`/crowdin.json
+php Build/BuildEssentials/Crowdin/Download.php `pwd`/crowdin.json
+php Build/BuildEssentials/Crowdin/Teardown.php `pwd`/crowdin.json
+
+# commit and push results to Framework dev collection
+cd Packages/Framework
+echo 'Commit and push to Framework'
+git ls-files -o | grep 'Translations' | xargs git add
+git commit -am 'TASK: Update translations from translation tool' || exit true
+git pull --rebase
+git config push.default simple
+git push origin
+cd -
+
+# commit and push results to Neos dev collection
+cd Packages/Neos
+echo 'Commit and push to Neos'
+git ls-files -o | grep 'Translations' | xargs git add
+git commit -am 'TASK: Update translations from translation tool' || exit true
+git pull --rebase
+git config push.default simple
+git push origin
+cd -
+
+# commit and push results to individual packages
+for PACKAGE in TYPO3.Form TYPO3.Neos.GoogleAnalytics TYPO3.Party TYPO3.Neos.Seo ; do
+    echo "Commit and push to ${PACKAGE}"
+    cd Packages/Application/${PACKAGE}
+    git ls-files -o | grep 'Translations' | xargs git add
+    git commit -am 'TASK: Update translations from translation tool' || true
+    git pull --rebase
+    git config push.default simple
+    git push origin
+    cd -
+done

--- a/crowdin.json
+++ b/crowdin.json
@@ -1,47 +1,21 @@
 {
-    "branch": "2.3",
-
-    "__bundle": {
-        "projectIdentifier": "neos",
+    "project": {
+        "branch": "2.3",
+        "identifier": "neos",
         "apiKey": "%CROWDIN_API_KEY%"
     },
 
-    "flow": {
-        "name": "TYPO3.Flow",
-        "path": "Packages/Framework/TYPO3.Flow"
-    },
-    "fluid": {
-        "name": "TYPO3.Fluid",
-        "path": "Packages/Framework/TYPO3.Fluid"
-    },
+    "items": {
+        "neos": {
+            "path": "Packages/Neos/*"
+        },
 
-    "media": {
-        "name": "TYPO3.Media",
-        "path": "Packages/Neos/TYPO3.Media"
-    },
-    "neos": {
-        "name": "TYPO3.Neos",
-        "path": "Packages/Neos/TYPO3.Neos"
-    },
-    "nodetypes": {
-        "name": "TYPO3.Neos.NodeTypes",
-        "path": "Packages/Neos/TYPO3.Neos.NodeTypes"
-    },
+        "framework": {
+            "path": "Packages/Framework/*"
+        },
 
-    "form": {
-        "name": "TYPO3.Form",
-        "path": "Packages/Application/TYPO3.Form"
-    },
-    "google-analytics": {
-        "name": "TYPO3.Neos.GoogleAnalytics",
-        "path": "Packages/Application/TYPO3.Neos.GoogleAnalytics"
-    },
-    "seo": {
-        "name": "TYPO3.Neos.Seo",
-        "path": "Packages/Application/TYPO3.Neos.Seo"
-    },
-    "party": {
-        "name": "TYPO3.Party",
-        "path": "Packages/Application/TYPO3.Party"
+        "addons": {
+            "path": "Packages/Application/TYPO3.*"
+        }
     }
 }


### PR DESCRIPTION
This updates the crowdin.json file for the 2.3 branch and adds a shell
script to sync sources and translations with crowdin.

That shell script basically contains the code that was in the job on
the Jenkins server as a build step.

A script to install composer is added as well, it can be used by other
scripts, too.