### PR TITLE
!!! FEATURE: Raise phpunit to v8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,48 +1,46 @@
 {
-    "name": "neos/neos-development-distribution",
-    "description" : "Neos Development Distribution",
-    "license": "GPL-3.0-or-later",
-    "support": {
-        "email": "hello@neos.io",
-        "slack": "http://slack.neos.io/",
-        "forum": "https://discuss.neos.io/",
-        "wiki": "https://discuss.neos.io/c/the-neos-project/project-documentation",
-        "issues": "https://github.com/neos/neos-development-collection/issues",
-        "docs": "http://neos.readthedocs.io/",
-        "source": "https://github.com/neos/neos-development-distribution"
-    },
-    "config": {
-        "vendor-dir": "Packages/Libraries",
-        "bin-dir": "bin"
-    },
-    "require": {
-        "neos/neos-development-collection": "@dev",
-        "neos/flow-development-collection": "@dev",
-        "neos/demo": "@dev",
-
-        "neos/neos-ui": "@dev",
-        "neos/neos-ui-compiled": "@dev",
-
-        "neos/party": "@dev",
-        "neos/seo": "@dev",
-        "neos/imagine": "@dev",
-        "neos/twitter-bootstrap": "@dev",
-        "neos/form": "@dev",
-        "neos/setup": "@dev",
-        "flowpack/neos-frontendlogin": "@dev",
-        "neos/buildessentials": "@dev",
-        "mikey179/vfsstream": "^1.6",
-        "phpunit/phpunit": "^7.1",
-        "symfony/css-selector": "^2.0",
-        "neos/behat": "dev-master"
-    },
-    "suggest": {
-        "ext-pdo_sqlite": "For running functional tests out-of-the-box this is required"
-    },
-    "scripts": {
-        "post-update-cmd": "Neos\\Flow\\Composer\\InstallerScripts::postUpdateAndInstall",
-        "post-install-cmd": "Neos\\Flow\\Composer\\InstallerScripts::postUpdateAndInstall",
-        "post-package-update": "Neos\\Flow\\Composer\\InstallerScripts::postPackageUpdateAndInstall",
-        "post-package-install": "Neos\\Flow\\Composer\\InstallerScripts::postPackageUpdateAndInstall"
-    }
+  "name": "neos/neos-development-distribution",
+  "description": "Neos Development Distribution",
+  "license": "GPL-3.0-or-later",
+  "support": {
+    "email": "hello@neos.io",
+    "slack": "http://slack.neos.io/",
+    "forum": "https://discuss.neos.io/",
+    "wiki": "https://discuss.neos.io/c/the-neos-project/project-documentation",
+    "issues": "https://github.com/neos/neos-development-collection/issues",
+    "docs": "http://neos.readthedocs.io/",
+    "source": "https://github.com/neos/neos-development-distribution"
+  },
+  "config": {
+    "vendor-dir": "Packages/Libraries",
+    "bin-dir": "bin"
+  },
+  "require": {
+    "neos/neos-development-collection": "@dev",
+    "neos/flow-development-collection": "@dev",
+    "neos/demo": "@dev",
+    "neos/neos-ui": "@dev",
+    "neos/neos-ui-compiled": "@dev",
+    "neos/party": "@dev",
+    "neos/seo": "@dev",
+    "neos/imagine": "@dev",
+    "neos/twitter-bootstrap": "@dev",
+    "neos/form": "@dev",
+    "neos/setup": "@dev",
+    "flowpack/neos-frontendlogin": "@dev",
+    "neos/buildessentials": "@dev",
+    "mikey179/vfsstream": "^1.6",
+    "phpunit/phpunit": "^8.1",
+    "symfony/css-selector": "^2.0",
+    "neos/behat": "dev-master"
+  },
+  "suggest": {
+    "ext-pdo_sqlite": "For running functional tests out-of-the-box this is required"
+  },
+  "scripts": {
+    "post-update-cmd": "Neos\\Flow\\Composer\\InstallerScripts::postUpdateAndInstall",
+    "post-install-cmd": "Neos\\Flow\\Composer\\InstallerScripts::postUpdateAndInstall",
+    "post-package-update": "Neos\\Flow\\Composer\\InstallerScripts::postPackageUpdateAndInstall",
+    "post-package-install": "Neos\\Flow\\Composer\\InstallerScripts::postPackageUpdateAndInstall"
+  }
 }


### PR DESCRIPTION
This change raises the phpunit requirement to v8.1. This might be breaking for you as phpunit introduced return types on methods like `public setUp(): void` as well as `public tearDown(): void`. PHPUnit also deprecated a lot of methods. You might find [here](https://thephp.cc/news/2019/02/help-my-tests-stopped-working) some more background information about replacements for your assertions.