### PR TITLE
TASK: Require fusion-form and fusion-afx in dev distribution

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,8 @@
     "neos/demo": "@dev",
     "neos/neos-ui": "@dev",
     "neos/neos-ui-compiled": "@dev",
+    "neos/fusion-afx": "@dev",
+    "neos/fusion-form": "@dev",
     "neos/party": "@dev",
     "neos/seo": "@dev",
     "neos/imagine": "@dev",


### PR DESCRIPTION
Add neos/fusion-form and neos/fusion-afx as dependencies to the development distribution.
This will make working on those packages easier until they will be incorporated into the dev-collection. 