### PR TITLE
BUGFIX: Add DistributionPackages folder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,12 @@
         "neos/media-browser": "4.3.x-dev",
         "neos/diff": "4.3.x-dev"
     },
+    "repositories": {
+        "distributionPackages": {
+            "type": "path",
+            "url": "./DistributionPackages/*"
+        }
+    },
     "suggest": {
         "ext-pdo_sqlite": "For running functional tests out-of-the-box this is required"
     },


### PR DESCRIPTION
This aligns the development distribution with the base distribution.
All packages in DistributionPackages are registered in the composer file as a local repository and can be required.