### PR TITLE
TASK: Update neos/behat and buildessentials version

### DIFF
--- a/Build/set-dependencies.sh
+++ b/Build/set-dependencies.sh
@@ -62,6 +62,8 @@ echo "Setting distribution dependencies"
 # Require exact versions of the main packages
 php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/neos:${VERSION}"
 php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/site-kickstarter:${VERSION}"
+php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/behat:${VERSION}"
+php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/buildessentials:${VERSION}"
 
 # Require exact versions of sub dependency packages, allowing unstable
 if [[ ${STABILITY_FLAG} ]] ; then


### PR DESCRIPTION
See https://github.com/neos/neos-base-distribution/pull/52#pullrequestreview-649289822

Note: This probably also needs an automatic tagging of a release for every x.x.0 version of Flow (see neos/flow-development-distribution#67)