### PR TITLE
TASK: Require strict dev-master of the dev-collections

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     "bin-dir": "bin"
   },
   "require": {
-    "neos/neos-development-collection": "@dev",
-    "neos/flow-development-collection": "@dev",
+    "neos/neos-development-collection": "dev-master",
+    "neos/flow-development-collection": "dev-master",
     "neos/demo": "@dev",
     "neos/neos-ui": "@dev",
     "neos/neos-ui-compiled": "@dev",


### PR DESCRIPTION
Under some (unknown) circumstances composer will try to install a X.Y.x-dev version instead of dev-master in builds (see https://github.com/neos/neos-development-collection/pull/3332#issuecomment-895905592). One way to prevent that would be to adjust the build script to require "dev-master" of the flow collection like is currently done for the (locally checked out) neos collection. Another is to adjust the require already in the master branch of the distribution here, since on release/branching off the two versions are adjusted to match the branch (see https://github.com/neos/neos-development-distribution/blob/7.1/composer.json#L19-L20).