### PR TITLE
TASK: Prefer installing of neos and flowpack packages from source

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "vendor-dir": "Packages/Libraries",
     "bin-dir": "bin",
     "preferred-install": {
-      "neos/*": "source"
+      "neos/*": "source",
+      "flowpack/*": "source"
     }
   },
   "require": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,10 @@
   },
   "config": {
     "vendor-dir": "Packages/Libraries",
-    "bin-dir": "bin"
+    "bin-dir": "bin",
+    "preferred-install": {
+      "neos/*": "source"
+    }
   },
   "require": {
     "neos/neos-development-collection": "@dev",


### PR DESCRIPTION
Since this is the development distribution for neos composer should install all neos packages from source.

Since quite some packages in the flowpack namespace are maintained by neos team members and some are
even installed in a default neos it makes our life easier to install packages from source in the development distribution aswell.

See https://getcomposer.org/doc/06-config.md#preferred-install

Resolves: #70 