### PR TITLE
TASK: Add tagging of Neos.Demo to the release scripts again

### DIFF
--- a/Build/create-branch.sh
+++ b/Build/create-branch.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Create a new branch for the distribution and the development collection
+# Create a new branch for the distribution, the development collection and the demo site
 #
 # Expects the following environment variables:
 #
@@ -36,10 +36,15 @@ push_branch "${BRANCH}" "Distribution"
 cd Packages/Neos && git checkout -b "${BRANCH}" origin/master ; cd -
 push_branch "${BRANCH}" "Packages/Neos"
 
+# branch demo site
+cd Packages/Sites/Neos.Demo && git checkout -b "${BRANCH}" origin/master ; cd -
+push_branch "${BRANCH}" "Packages/Sites/Neos.Demo"
+
 $(dirname ${BASH_SOURCE[0]})/set-dependencies.sh "${BRANCH}.x-dev" "${BRANCH}" "${FLOW_BRANCH}" "${BUILD_URL}" || exit 1
 
 push_branch "${BRANCH}" "Distribution"
 push_branch "${BRANCH}" "Packages/Neos"
+push_branch "${BRANCH}" "Packages/Sites/Neos.Demo"
 
 # same procedure again with the Development Distribution
 

--- a/Build/set-dependencies.sh
+++ b/Build/set-dependencies.sh
@@ -61,6 +61,7 @@ echo "Setting distribution dependencies"
 
 # Require exact versions of the main packages
 php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/neos:${VERSION}"
+php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/demo:${VERSION}"
 php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/site-kickstarter:${VERSION}"
 php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/behat:${VERSION}"
 php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/buildessentials:${VERSION}"

--- a/Build/tag-release.sh
+++ b/Build/tag-release.sh
@@ -52,3 +52,8 @@ echo "Tagging development collection"
 tag_version "${VERSION}" "${BRANCH}" "${BUILD_URL}" "Packages/Neos"
 push_branch "${BRANCH}" "Packages/Neos"
 push_tag "${VERSION}" "Packages/Neos"
+
+echo "Tagging demo package"
+tag_version "${VERSION}" "${BRANCH}" "${BUILD_URL}" "Packages/Sites/Neos.Demo"
+push_branch "${BRANCH}" "Packages/Sites/Neos.Demo"
+push_tag "${VERSION}" "Packages/Sites/Neos.Demo"


### PR DESCRIPTION
Since version 4.3 Neos Demo had a separate version number from Neos but since Neos 7 Neos.Demo and Neos are in sync again. This change adds the creating of branches and releases for Neos.Demo to the release job again to ease the job of the releaser managers a little.

Note: The now reverted changes were added here https://github.com/neos/neos-development-distribution/pull/47 