### PR TITLE
TASK: Show welcome message after composer create-project and adjust set-dependencies script

### DIFF
--- a/Build/set-dependencies.sh
+++ b/Build/set-dependencies.sh
@@ -63,6 +63,7 @@ echo "Setting distribution dependencies"
 php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/neos:${VERSION}"
 php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/demo:${VERSION}"
 php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/site-kickstarter:${VERSION}"
+php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/cli-setup:${VERSION}"
 php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/behat:${VERSION}"
 php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/buildessentials:${VERSION}"
 

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
     "ext-pdo_sqlite": "For running functional tests out-of-the-box this is required"
   },
   "scripts": {
-    "post-create-project-cmd": "./flow welcome"
+    "post-create-project-cmd": "./flow welcome",
     "post-update-cmd": "Neos\\Flow\\Composer\\InstallerScripts::postUpdateAndInstall",
     "post-install-cmd": "Neos\\Flow\\Composer\\InstallerScripts::postUpdateAndInstall",
     "post-package-update": "Neos\\Flow\\Composer\\InstallerScripts::postPackageUpdateAndInstall",

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
     "ext-pdo_sqlite": "For running functional tests out-of-the-box this is required"
   },
   "scripts": {
+    "post-create-project-cmd": "./flow welcome"
     "post-update-cmd": "Neos\\Flow\\Composer\\InstallerScripts::postUpdateAndInstall",
     "post-install-cmd": "Neos\\Flow\\Composer\\InstallerScripts::postUpdateAndInstall",
     "post-package-update": "Neos\\Flow\\Composer\\InstallerScripts::postPackageUpdateAndInstall",


### PR DESCRIPTION
Add `./flow welcome` as post create project command to the composer json which shows the required steps to setup neos by cli.

Additionally this adds neos/cli-setup to the set dependencies script to ensure the bae distribution requires the matching version.

Relates: https://github.com/neos/neos-development-collection/pull/3505, https://github.com/neos/neos-development-collection/issues/3506
