### PR TITLE
TASK: Automatically generate release notes when creating a minor or major release

### DIFF
--- a/Build/release.sh
+++ b/Build/release.sh
@@ -28,6 +28,9 @@ fi
 composer.phar -vn clear-cache
 composer.phar -vn update
 Build/create-changelog.sh
+if [[ "$VERSION" == *.0 ]]
+  Build/create-releasenotes.sh
+fi
 Build/tag-release.sh "${VERSION}" "${BRANCH}" "${FLOW_BRANCH}" "${BUILD_URL}"
 
 #


### PR DESCRIPTION
This is done by checking if the released version string ends with ".0" and if so, invokes the `create-releasenotes.sh` script