### PR TITLE
FEATURE: Dramatically improve docker dev setup overall performance

### DIFF
--- a/Configuration/Development/Docker/Caches.yaml
+++ b/Configuration/Development/Docker/Caches.yaml
@@ -1,0 +1,47 @@
+Flow_Mvc_Routing_Route:
+  backend: 'Neos\Cache\Backend\RedisBackend'
+  backendOptions:
+    hostname: '%env:REDIS_HOST%'
+    port: '%env:REDIS_PORT%'
+    database: 2
+    defaultLifetime: 0
+
+Flow_Mvc_Routing_Resolve:
+  backend: 'Neos\Cache\Backend\RedisBackend'
+  backendOptions:
+    hostname: '%env:REDIS_HOST%'
+    port: '%env:REDIS_PORT%'
+    database: 2
+    defaultLifetime: 0
+
+Neos_Fusion_Content:
+  backend: 'Neos\Cache\Backend\RedisBackend'
+  backendOptions:
+    hostname: '%env:REDIS_HOST%'
+    port: '%env:REDIS_PORT%'
+    database: 2
+    defaultLifetime: 0
+
+Flow_Session_MetaData:
+  backend: 'Neos\Cache\Backend\RedisBackend'
+  backendOptions:
+    hostname: '%env:REDIS_HOST%'
+    port: '%env:REDIS_PORT%'
+    database: 2
+    defaultLifetime: 0
+
+Flow_Session_Storage:
+  backend: 'Neos\Cache\Backend\RedisBackend'
+  backendOptions:
+    hostname: '%env:REDIS_HOST%'
+    port: '%env:REDIS_PORT%'
+    database: 2
+    defaultLifetime: 0
+
+Neos_Media_ImageSize:
+  backend: 'Neos\Cache\Backend\RedisBackend'
+  backendOptions:
+    hostname: '%env:REDIS_HOST%'
+    port: '%env:REDIS_PORT%'
+    database: 2
+    defaultLifetime: 0

--- a/Configuration/Development/Docker/Settings.yaml
+++ b/Configuration/Development/Docker/Settings.yaml
@@ -16,19 +16,12 @@ Neos:
       backendOptions:
         charset: 'utf8mb4'
         host: '%env:DB_NEOS_HOST%'
-        dbname: '%env:DB_NEOS_DATABASE%'       # adjust to your database name
-        user: '%env:DB_NEOS_USER%'             # adjust to your database user
-        password: '%env:DB_NEOS_PASSWORD%'         # adjust to your database password
-
-       # if you want to log executed SQL queries, enable the next 2 lines
-#      doctrine:
-#        sqlLogger: 'Neos\Flow\Persistence\Doctrine\Logging\SqlLogger'
-
-    # If you are running Flow within a Docker environment, you probably need to allow all proxies,
-    # because the container acts as such and the IP is variable.
-#    http:
-#      trustedProxies:
-#        proxies: '*'
+        port: '%env:DB_NEOS_PORT%'
+        dbname: '%env:DB_NEOS_DATABASE%'
+        user: '%env:DB_NEOS_USER%'
+        password: '%env:DB_NEOS_PASSWORD%'
+    cache:
+      applicationIdentifier: 'app'
 
   Imagine:
     driver: Gmagick

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,9 @@ services:
       # Neos
       ADMIN_USERNAME: 'admin'
       ADMIN_PASSWORD: 'password'
+      # cache
+      REDIS_HOST: 'redis-cache'
+      REDIS_PORT: 6379
     volumes:
       - ./composer.json:/app/composer.json:cached
       # Explicitly set up Composer cache for faster fetching of packages
@@ -27,10 +30,9 @@ services:
       - ./Configuration:/app/Configuration:cached
     ports:
       - '8081:8081'
-    networks:
-      - neosdevelopment
     depends_on:
       - db
+      - redis-cache
 
   db:
     image: mariadb:10.11
@@ -43,11 +45,11 @@ services:
       - db:/var/lib/mysql
     ports:
       - '13306:3306'
-    networks:
-      - neosdevelopment
+
+  redis-cache:
+    image: redis:6.2.2
+    ports:
+      - 16379:6379
+
 volumes:
   db:
-
-networks:
-  neosdevelopment:
-    name: neosdevelopment

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,9 @@
-FROM php:8.1-cli
+FROM php:8.1-fpm
 
-RUN apt-get update \
+RUN apt-get update -y \
     # install GraphicsMagick
-	&& apt-get install -y \
-		libgraphicsmagick1-dev graphicsmagick zlib1g-dev libicu-dev gcc g++ --no-install-recommends \
+	&& apt-get install --no-install-recommends -y \
+		libgraphicsmagick1-dev graphicsmagick zlib1g-dev libicu-dev gcc g++ \
 	&& pecl -vvv install gmagick-beta && docker-php-ext-enable gmagick \
     # pdo_mysql
     && docker-php-ext-install pdo_mysql \
@@ -12,7 +12,7 @@ RUN apt-get update \
 	# intl
 	&& docker-php-ext-configure intl && docker-php-ext-install intl \
     # tools
-    && apt-get install -y unzip git vim default-mysql-client \
+    && apt-get install -y unzip git vim less default-mysql-client nginx-light \
     # cleanup
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
@@ -21,15 +21,23 @@ COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 
 ADD /docker/entrypoint.sh /
 
+# remove existing fpm and nginx configs
+RUN rm -Rf /usr/local/etc/php-fpm.* && rm -Rf /etc/nginx/conf.d/*
+
+# add config files
 ADD /docker/config-files/memory-limit-php.ini /usr/local/etc/php/conf.d/memory-limit-php.ini
 ADD /docker/config-files/upload-limit-php.ini /usr/local/etc/php/conf.d/upload-limit-php.ini
+ADD /docker/config-files/php-fpm.conf /usr/local/etc/php-fpm.conf
+ADD /docker/config-files/nginx.conf /etc/nginx/
 
+# make sure some directories exist
 RUN mkdir -p /app/DistributionPackages
 RUN mkdir -p /app/Configuration/Development
 RUN mkdir -p /.composer
+RUN mkdir -p /var/lib/nginx /usr/local/var/log/
 
-RUN chown -R 1000:1000 entrypoint.sh /app /.composer
-RUN chmod +x entrypoint.sh
+RUN chown -R 1000:1000 /entrypoint.sh /app /.composer /var/lib/nginx /usr/local/var/log/ /var/log/ /etc/nginx/ /var/www
+RUN chmod +x /entrypoint.sh
 
 USER 1000:1000
 

--- a/docker/config-files/nginx.conf
+++ b/docker/config-files/nginx.conf
@@ -1,0 +1,124 @@
+worker_processes  auto;
+error_log stderr warn;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /tmp/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    access_log  /dev/stdout;
+
+    log_format  main  '[$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    # gzip on; – enables gzip compression
+    gzip on;
+    # gzip_vary on: – tells proxies to cache both gzipped and regular versions of a resource
+    gzip_vary on;
+    # gzip_min_length 1024; – informs NGINX to not compress anything smaller than the defined size
+    gzip_min_length 1024;
+    # gzip_proxied – compress data even for clients that are connecting via proxies (here we’re enabling compression if: a response header includes the “expired”, “no-cache”, “no-store”, “private”, and “Authorization” parameters)
+    gzip_proxied any;
+    # gzip_comp_level 6; - Sets a gzip compression level of a response. Acceptable values are in the range from 1 to 9.
+    gzip_comp_level 6;
+    # gzip_http_version 1.0 –  Sets the minimum HTTP version of a request required to compress a response.
+    gzip_http_version 1.0;
+    # gzip_types – Enables gzipping of responses for the specified MIME types in addition to “text/html”. The special value “*” matches any MIME type (0.8.29). Responses with the “text/html” type are always compressed.
+    gzip_types
+        application/atom+xml
+        application/javascript
+        application/json
+        application/ld+json
+        application/manifest+json
+        application/msword
+        application/rss+xml
+        application/pdf
+        application/vnd.geo+json
+        application/vnd.ms-fontobject
+        application/xhtml+xml
+        application/xml
+        application/xspf+xml
+        application/x-font-ttf
+        application/x-web-app-manifest+json
+        application/x-x509-ca-cert
+        font/opentype
+        font/woff2
+        image/bmp
+        image/svg+xml
+        image/x-icon
+        text/cache-manifest
+        text/css
+        # text/html always compressed anyway
+        text/javascript
+        text/mathml
+        text/plain
+        text/vcard
+        text/vnd.sun.j2me.app-descriptor
+        text/vnd.wap.wml
+        text/vnd.rim.location.xloc
+        text/vtt
+        text/xml
+        text/x-component
+        text/x-cross-domain-policy
+        ;
+    # more gzip info https://markontech.com/hosting/enable-gzip-compression-on-nginx/
+    # more gzip info https://nginx.org/en/docs/http/ngx_http_gzip_module.html
+
+    client_max_body_size 256m;
+
+    proxy_cache_path  /tmp/nginx-maptiles-cache  levels=1:2  keys_zone=MAPTILES:10m inactive=24h  max_size=1g;
+
+    server {
+        listen       8081;
+        server_name  0.0.0.0;
+        root   /app/Web;
+        index index.html index.htm index.php;
+
+        location / {
+            try_files $uri $uri/ /index.php?$args;
+        }
+
+        location ~ "^/_Resources/" {
+            access_log off;
+            log_not_found off;
+            expires max;
+            break;
+        }
+
+        location ~* \.php$ {
+            fastcgi_pass   unix:/tmp/php7-fpm.sock;
+            include        fastcgi_params;
+            fastcgi_index  index.php;
+            fastcgi_param  SCRIPT_FILENAME   $document_root$fastcgi_script_name;
+            fastcgi_param  SCRIPT_NAME       $fastcgi_script_name;
+            fastcgi_param  PATH_INFO         $fastcgi_path_info;
+            fastcgi_param  FLOW_REWRITEURLS  1;
+            fastcgi_param  X-Forwarded-For   $proxy_add_x_forwarded_for;
+            fastcgi_param  X-Forwarded-Port  $proxy_port;
+            fastcgi_param  REMOTE_ADDR       $remote_addr;
+            fastcgi_param  REMOTE_PORT       $remote_port;
+            fastcgi_param  SERVER_ADDR       $server_addr;
+            fastcgi_param  SERVER_NAME       $http_host;
+            fastcgi_split_path_info ^(.+\.php)(.*)$;
+            fastcgi_read_timeout         300;
+            fastcgi_buffer_size          128k;
+            fastcgi_buffers              256 16k;
+            fastcgi_busy_buffers_size    256k;
+            fastcgi_temp_file_write_size 256k;
+        }
+    }
+
+    include conf.d/*.conf;
+}

--- a/docker/config-files/php-fpm.conf
+++ b/docker/config-files/php-fpm.conf
@@ -1,0 +1,21 @@
+[global]
+; Pid file
+; Note: the default prefix is /usr/local/var
+; Default Value: none
+pid = /tmp/php-fpm.pid
+
+
+; Send FPM to background. Set to 'no' to keep FPM in foreground for debugging.
+; Default Value: yes
+daemonize = no
+
+[www]
+clear_env = false
+user = 1000
+group = 1000
+listen = /tmp/php7-fpm.sock
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,20 +5,21 @@ composer install
 ./flow database:setcharset
 ./flow doctrine:migrate
 
-# only run site import when nothing was imported before
-importedSites=`./flow site:list`
+# only run site import when no site is present
+importedSites=$(./flow site:list)
 if [ "$importedSites" = "No sites available" ]; then
     echo "Importing content from Demo"
     ./flow site:import --package-key="Neos.Demo"
 fi
 
-./flow user:create --roles Administrator $ADMIN_USERNAME $ADMIN_PASSWORD LocalDev Admin || true
+./flow user:create --roles Administrator "$ADMIN_USERNAME" "$ADMIN_PASSWORD" LocalDev Admin || true
 
 ./flow resource:publish
 ./flow flow:cache:flush
 ./flow cache:warmup
 
-./flow server:run --host 0.0.0.0
-# e2e test
-#./flow behat:setup
-#rm bin/selenium-server.jar # we do not need this
+# start nginx in background
+nginx &
+
+# start PHP-FPM
+exec /usr/local/sbin/php-fpm


### PR DESCRIPTION
Add _basic(tm)_ nginx, fpm and redis to docker dev setup.

WHY nginx & fpm: Handle requests faster and in parallel.
WHY redis: faster cache.

This makes neos performance a lot better, _but_ also introduces a lot of complexity to the setup with 3 new tools.

So this might be up to discussion.