### PR TITLE
BUGFIX: Pin Flow to a version that supports authentication

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   },
   "require": {
     "neos/neos-development-collection": "9.0.x-dev",
-    "neos/flow-development-collection": "9.0.x-dev",
+    "neos/flow-development-collection": "9.0.x-dev#ff724597bdf1832625c02aba317577324251a7a7",
     "neos/eventstore": "dev-main",
     "neos/eventstore-doctrineadapter": "dev-main",
     "neos/demo": "@dev",


### PR DESCRIPTION
Pins the version of Flow to commit ff724597bdf1832625c02aba317577324251a7a7 that contains a working version before the Proxy Class Refactoring.

*Note:* This is just a temporary work around until Flow 9.0 is stable again

Related: https://github.com/neos/flow-development-collection/issues/3062