### PR TITLE
Revert "BUGFIX: Pin Flow to a version that supports authentication"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   },
   "require": {
     "neos/neos-development-collection": "9.0.x-dev",
-    "neos/flow-development-collection": "9.0.x-dev#ff724597bdf1832625c02aba317577324251a7a7",
+    "neos/flow-development-collection": "9.0.x-dev",
     "neos/eventstore": "dev-main",
     "neos/eventstore-doctrineadapter": "dev-main",
     "neos/demo": "@dev",


### PR DESCRIPTION
Reverts neos/neos-development-distribution#91 since the bug has been fixed with https://github.com/neos/flow-development-collection/pull/3063 in the meantime