### PR TITLE
 TASK: Adds neos/neos-setup as dependency 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
     "ext-pdo_sqlite": "For running functional tests out-of-the-box this is required"
   },
   "scripts": {
-    "post-create-project-cmd": "./flow setup:index",
+    "post-create-project-cmd": "./flow setup",
     "post-update-cmd": "Neos\\Flow\\Composer\\InstallerScripts::postUpdateAndInstall",
     "post-install-cmd": "Neos\\Flow\\Composer\\InstallerScripts::postUpdateAndInstall",
     "post-package-update": "Neos\\Flow\\Composer\\InstallerScripts::postPackageUpdateAndInstall",

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
   "require": {
     "neos/neos-development-collection": "8.0.x-dev",
     "neos/flow-development-collection": "8.0.x-dev",
+    "neos/neos-setup": "3.x-dev",
     "neos/demo": "8.0.x-dev",
     "neos/neos-ui": "8.0.x-dev",
     "neos/neos-ui-compiled": "8.0.x-dev",
@@ -51,7 +52,7 @@
     "ext-pdo_sqlite": "For running functional tests out-of-the-box this is required"
   },
   "scripts": {
-    "post-create-project-cmd": "./flow welcome",
+    "post-create-project-cmd": "./flow setup:index",
     "post-update-cmd": "Neos\\Flow\\Composer\\InstallerScripts::postUpdateAndInstall",
     "post-install-cmd": "Neos\\Flow\\Composer\\InstallerScripts::postUpdateAndInstall",
     "post-package-update": "Neos\\Flow\\Composer\\InstallerScripts::postPackageUpdateAndInstall",


### PR DESCRIPTION
As we removed neos/neos-setup from neos/neos-development-collection dependencies, we need to declare it here. This change also updates the welcome command to setup, as welcome is just an alias for the previous CLI setup.

This is related to https://github.com/neos/neos-development-collection/pull/4803