### PR TITLE
BUGFIX: Pull in `neos/demo` as `9.0.x-dev` explicitly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   "require": {
     "neos/neos-development-collection": "9.0.x-dev",
     "neos/flow-development-collection": "9.0.x-dev",
-    "neos/demo": "@dev",
+    "neos/demo": "9.0.x-dev",
     "neos/neos-ui": "9.0.x-dev",
     "neos/neos-ui-compiled": "@dev",
     "neos/fusion-form": "@dev",


### PR DESCRIPTION
This hopefully solves the tagging error during release.