### PR TITLE
FEATURE: Collections as path repo's

### DIFF
--- a/Build/clone-neos.sh
+++ b/Build/clone-neos.sh
@@ -1,4 +1,0 @@
-#!/bin/bash -xe
-
-git clone git@github.com:neos/neos-development-collection.git NeosCollection
-git clone git@github.com:neos/flow-development-collection.git FlowCollection

--- a/Build/clone-neos.sh
+++ b/Build/clone-neos.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -xe
+
+git clone git@github.com:neos/neos-development-collection.git NeosCollection

--- a/Build/clone-neos.sh
+++ b/Build/clone-neos.sh
@@ -1,3 +1,4 @@
 #!/bin/bash -xe
 
 git clone git@github.com:neos/neos-development-collection.git NeosCollection
+git clone git@github.com:neos/flow-development-collection.git FlowCollection

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   "require": {
     "neos/neos": "@dev",
     "neos/contentgraph-doctrinedbaladapter": "@dev",
-    "neos/flow-development-collection": "9.0.x-dev",
+    "neos/flow": "@dev",
     "neos/demo": "9.0.x-dev",
     "neos/neos-ui": "9.0.x-dev",
     "neos/fusion-form": "@dev",
@@ -43,9 +43,13 @@
       "type": "path",
       "url": "./DistributionPackages/*"
     },
-    "neosPackages": {
+    "neosCollectionPackages": {
       "type": "path",
       "url": "./NeosCollection/*"
+    },
+    "flowCollectionPackages": {
+      "type": "path",
+      "url": "./FlowCollection/*"
     }
   },
   "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
   "prefer-stable": true,
   "require": {
     "neos/neos": "@dev",
+    "neos/contentgraph-doctrinedbaladapter": "@dev",
     "neos/flow-development-collection": "9.0.x-dev",
     "neos/demo": "9.0.x-dev",
     "neos/neos-ui": "9.0.x-dev",

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,12 @@
     "test-unit": "phpunit -c Build/BuildEssentials/PhpUnit/UnitTests.xml",
     "test-functional": "phpunit -c Build/BuildEssentials/PhpUnit/FunctionalTests.xml",
     "benchmark": "tools/phpbench run --report=aggregate",
-    "post-root-package-install": ". ./Build/clone-neos.sh"
+    "install-neos-collection": "@composer create-project neos/neos-development-collection NeosCollection 9.0.x-dev --no-install --no-scripts --keep-vcs --prefer-source",
+    "install-flow-collection": "@composer create-project neos/flow-development-collection FlowCollection 9.0.x-dev --no-install --no-scripts --keep-vcs --prefer-source", 
+    "post-root-package-install": [
+      "@install-neos-collection",
+      "@install-flow-collection"
+    ]
   },
   "require-dev": {
     "neos/behat": "9.0.x-dev",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
-    "neos/neos-development-collection": "9.0.x-dev",
+    "neos/neos": "@dev",
     "neos/flow-development-collection": "9.0.x-dev",
     "neos/demo": "9.0.x-dev",
     "neos/neos-ui": "9.0.x-dev",
@@ -41,6 +41,10 @@
     "distributionPackages": {
       "type": "path",
       "url": "./DistributionPackages/*"
+    },
+    "neosPackages": {
+      "type": "path",
+      "url": "./NeosCollection/*"
     }
   },
   "suggest": {
@@ -54,7 +58,8 @@
     "post-package-install": "Neos\\Flow\\Composer\\InstallerScripts::postPackageUpdateAndInstall",
     "test-unit": "phpunit -c Build/BuildEssentials/PhpUnit/UnitTests.xml",
     "test-functional": "phpunit -c Build/BuildEssentials/PhpUnit/FunctionalTests.xml",
-    "benchmark": "tools/phpbench run --report=aggregate"
+    "benchmark": "tools/phpbench run --report=aggregate",
+    "post-root-package-install": ". ./Build/clone-neos.sh"
   },
   "require-dev": {
     "neos/behat": "9.0.x-dev",


### PR DESCRIPTION
demonstration how we could install Neos and Flow dev collections without depending on our ComposerManifest merger and the Flow mono repo support for `type: "neos-package-collection"`



install via 

```
composer create-project --repository '{"type":"vcs", "url":"git@github.com:mhsdesign/neos-development-distribution.git"}' neos/neos-development-distribution neos-dev-dist dev-feature/neos-collection-as-path-rep
```

TODO:

- `flow:server:run` does not work vs `php -S localhost:8001 -t Web` because all the path traversals in Flow dont work as the packages are symlinked now
  - `Bootstrap` without autoload
  - `PhpDevelopmentServerRouter`

