### PR TITLE
TASK: Avoid cloning big ui compiled package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "vendor-dir": "Packages/Libraries",
     "bin-dir": "bin",
     "preferred-install": {
+      "neos/neos-ui-compiled": "dist",
       "neos/*": "source",
       "flowpack/*": "source"
     },


### PR DESCRIPTION
@jrenggli and me noticed that setting up a new dev environment is  slow due to the clone of `neos/neos-ui-compiled` which is currently 1.3gb in size. That is normally no problem as we distribute the dist version. But during local development cloning 1.3gb is just redundant and not at all required. No developer needs access to the git history.

This change needs to be upmerged to 9.2