### PR TITLE
TASK: Simplify beta releases by using composer minimum stability and fix dependencies for Neos 9

### DIFF
--- a/Build/set-dependencies.sh
+++ b/Build/set-dependencies.sh
@@ -78,11 +78,11 @@ if [[ ${STABILITY_FLAG} ]]; then
   else
     COMPOSER_STABILITY_FLAG="dev"
   fi
-  composer config minimum-stability $COMPOSER_STABILITY_FLAG
-  composer config prefer-stable true
+  php "${COMPOSER_PHAR}" --working-dir=Distribution config minimum-stability $COMPOSER_STABILITY_FLAG
+  php "${COMPOSER_PHAR}" --working-dir=Distribution config prefer-stable true
 else
-  composer config --unset prefer-stable
-  composer config --unset minimum-stability
+  php "${COMPOSER_PHAR}" --working-dir=Distribution config --unset prefer-stable
+  php "${COMPOSER_PHAR}" --working-dir=Distribution config --unset minimum-stability
 fi
 
 # Require main dev dependencies

--- a/Build/set-dependencies.sh
+++ b/Build/set-dependencies.sh
@@ -25,11 +25,11 @@ if [ -z "$1" ]; then
   exit 1
 else
   if [[ $1 =~ (dev)-.+ || $1 =~ .+(@dev|.x-dev) || $1 =~ (alpha|beta|RC|rc)[0-9]+ ]]; then
-    VERSION="$1"
+    EXACT_VERSION_OR_MINOR="$1"
     STABILITY_FLAG=${BASH_REMATCH[1]}
   else
     if [[ $1 =~ ([0-9]+\.[0-9]+)\.[0-9] ]]; then
-      VERSION=~${BASH_REMATCH[1]}.0
+      EXACT_VERSION_OR_MINOR="~${BASH_REMATCH[1]}.0"
     else
       echo >&2 "Version $1 could not be parsed."
       exit 1
@@ -62,10 +62,10 @@ fi
 
 echo "Setting distribution dependencies"
 
-# Require exact versions of the main packages
-php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/neos:${VERSION}
-php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/contentgraph-doctrinedbaladapter:${VERSION}"
-php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/demo:${VERSION}"
+# Require exact versions or minor level of the main packages
+php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/neos:${EXACT_VERSION_OR_MINOR}"
+php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/contentgraph-doctrinedbaladapter:${EXACT_VERSION_OR_MINOR}"
+php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/demo:${EXACT_VERSION_OR_MINOR}"
 
 # Require separately released Neos Ui in the minor range of the Neos branch to tag.
 # Uses when tagging a beta via "minimum-stability" the next available tag
@@ -86,7 +86,7 @@ else
 fi
 
 # Require main dev dependencies
-php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/site-kickstarter:${VERSION}"
+php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/site-kickstarter:${EXACT_VERSION_OR_MINOR}"
 # ...from flow release
 if [[ ${STABILITY_FLAG} ]]; then
   # using alias as "stable" so neos testing helper packages can declare a dependency
@@ -97,7 +97,7 @@ else
   php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/behat:~${FLOW_BRANCH}.0"
 fi
 
-commit_manifest_update "${BRANCH}" "${BUILD_URL}" "${VERSION}" "Distribution"
+commit_manifest_update "${BRANCH}" "${BUILD_URL}" "${EXACT_VERSION_OR_MINOR}" "Distribution"
 
 php "${COMPOSER_PHAR}" --working-dir=Packages/Neos/Neos.Neos require --no-update "neos/flow:~${FLOW_BRANCH}.0"
 php "${COMPOSER_PHAR}" --working-dir=Packages/Neos/Neos.Neos require --no-update "neos/fluid-adaptor:~${FLOW_BRANCH}.0"
@@ -111,4 +111,4 @@ git add .composer.json
 php ../../Build/BuildEssentials/ComposerManifestMerger.php
 cd - || exit 1
 
-commit_manifest_update "${BRANCH}" "${BUILD_URL}" "${VERSION}" "Packages/Neos"
+commit_manifest_update "${BRANCH}" "${BUILD_URL}" "${EXACT_VERSION_OR_MINOR}" "Packages/Neos"

--- a/Build/set-dependencies.sh
+++ b/Build/set-dependencies.sh
@@ -67,6 +67,10 @@ php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/neos
 php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/contentgraph-doctrinedbaladapter:${VERSION}"
 php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/demo:${VERSION}"
 
+# Require separately released Neos Ui in the minor range of the Neos branch to tag.
+# Uses when tagging a beta via "minimum-stability" the next available tag
+php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/neos-ui:~${BRANCH}.0"
+
 # Allow main packages require their required sub dependency packages, allowing unstable
 if [[ ${STABILITY_FLAG} ]]; then
   if [[ "$STABILITY_FLAG" =~ ^(dev|alpha|beta|RC|rc)$ ]]; then

--- a/Build/set-dependencies.sh
+++ b/Build/set-dependencies.sh
@@ -90,8 +90,12 @@ php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neo
 # ...from flow release
 if [[ ${STABILITY_FLAG} ]]; then
   # using alias as "stable" so neos testing helper packages can declare a dependency
-  php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/buildessentials:${FLOW_BRANCH}.x-dev as ${FLOW_BRANCH}"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/behat:${FLOW_BRANCH}.x-dev as ${FLOW_BRANCH}"
+  STABILITY_ALIAS=" as ${BRANCH}"
+  if [[ "${COMPOSER_STABILITY_FLAG}" == "dev" ]]; then
+    STABILITY_ALIAS=""
+  fi
+  php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/behat:${BRANCH}.x-dev${STABILITY_ALIAS}"
+  php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/buildessentials:${BRANCH}.x-dev${STABILITY_ALIAS}"
 else
   php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/buildessentials:~${FLOW_BRANCH}.0"
   php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/behat:~${FLOW_BRANCH}.0"

--- a/Build/set-dependencies.sh
+++ b/Build/set-dependencies.sh
@@ -63,10 +63,9 @@ fi
 echo "Setting distribution dependencies"
 
 # Require exact versions of the main packages
-php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/neos:${VERSION}"
-php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/demo:${VERSION}"
+php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/neos:${VERSION}
 php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/contentgraph-doctrinedbaladapter:${VERSION}"
-php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/site-kickstarter:${VERSION}"
+php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/demo:${VERSION}"
 
 # Allow main packages require their required sub dependency packages, allowing unstable
 if [[ ${STABILITY_FLAG} ]]; then
@@ -82,7 +81,9 @@ else
   composer config --unset minimum-stability
 fi
 
-# Require main dev dependencies (from flow release)
+# Require main dev dependencies
+php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/site-kickstarter:${VERSION}"
+# ...from flow release
 if [[ ${STABILITY_FLAG} ]]; then
   # using alias as "stable" so neos testing helper packages can declare a dependency
   php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/buildessentials:${FLOW_BRANCH}.x-dev as ${FLOW_BRANCH}"

--- a/Build/set-dependencies.sh
+++ b/Build/set-dependencies.sh
@@ -67,10 +67,6 @@ php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/neos
 php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/contentgraph-doctrinedbaladapter:${EXACT_VERSION_OR_MINOR}"
 php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/demo:${EXACT_VERSION_OR_MINOR}"
 
-# Require separately released Neos Ui in the minor range of the Neos branch to tag.
-# Uses when tagging a beta via "minimum-stability" the next available tag
-php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/neos-ui:~${BRANCH}.0"
-
 # Allow main packages require their required sub dependency packages, allowing unstable
 if [[ ${STABILITY_FLAG} ]]; then
   if [[ "$STABILITY_FLAG" =~ ^(dev|alpha|beta|RC|rc)$ ]]; then
@@ -101,7 +97,13 @@ else
   php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/behat:~${FLOW_BRANCH}.0"
 fi
 
-commit_manifest_update "${BRANCH}" "${BUILD_URL}" "${EXACT_VERSION_OR_MINOR}" "Distribution"
+if [[ "${COMPOSER_STABILITY_FLAG}" == "dev" ]]; then
+  php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/neos-ui:${BRANCH}.x-dev"
+else
+  # Require separately released Neos Ui in the minor range of the Neos branch to tag.
+  # Uses when tagging a beta via "minimum-stability" the next available tag
+  php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/neos-ui:~${BRANCH}.0"
+fi
 
 php "${COMPOSER_PHAR}" --working-dir=Packages/Neos/Neos.Neos require --no-update "neos/flow:~${FLOW_BRANCH}.0"
 php "${COMPOSER_PHAR}" --working-dir=Packages/Neos/Neos.Neos require --no-update "neos/fluid-adaptor:~${FLOW_BRANCH}.0"

--- a/Build/set-dependencies.sh
+++ b/Build/set-dependencies.sh
@@ -67,7 +67,6 @@ php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/neos
 php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/demo:${VERSION}"
 php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/contentgraph-doctrinedbaladapter:${VERSION}"
 php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/site-kickstarter:${VERSION}"
-php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/buildessentials:${VERSION}"
 
 # Allow main packages require their required sub dependency packages, allowing unstable
 if [[ ${STABILITY_FLAG} ]]; then
@@ -81,6 +80,13 @@ if [[ ${STABILITY_FLAG} ]]; then
 else
   composer config --unset prefer-stable
   composer config --unset minimum-stability
+fi
+
+# Require main dev dependencies (from flow release)
+if [[ ${STABILITY_FLAG} ]]; then
+  php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/buildessentials:${FLOW_BRANCH}.x-dev"
+else
+  php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/buildessentials:~${FLOW_BRANCH}.0"
 fi
 
 commit_manifest_update "${BRANCH}" "${BUILD_URL}" "${VERSION}" "Distribution"

--- a/Build/set-dependencies.sh
+++ b/Build/set-dependencies.sh
@@ -105,6 +105,8 @@ else
   php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/neos-ui:~${BRANCH}.0"
 fi
 
+commit_manifest_update "${BRANCH}" "${BUILD_URL}" "${VERSION}" "Distribution"
+
 php "${COMPOSER_PHAR}" --working-dir=Packages/Neos/Neos.Neos require --no-update "neos/flow:~${FLOW_BRANCH}.0"
 php "${COMPOSER_PHAR}" --working-dir=Packages/Neos/Neos.Neos require --no-update "neos/fluid-adaptor:~${FLOW_BRANCH}.0"
 php "${COMPOSER_PHAR}" --working-dir=Packages/Neos/Neos.ContentRepositoryRegistry.TestSuite require --no-update "neos/behat:~${FLOW_BRANCH}.0"

--- a/Build/set-dependencies.sh
+++ b/Build/set-dependencies.sh
@@ -69,34 +69,18 @@ php "${COMPOSER_PHAR}" --working-dir=Distribution require --no-update "neos/cont
 php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/site-kickstarter:${VERSION}"
 php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/buildessentials:${VERSION}"
 
-# Require exact versions of sub dependency packages, allowing unstable
+# Allow main packages require their required sub dependency packages, allowing unstable
 if [[ ${STABILITY_FLAG} ]]; then
-  echo 'Detected stability flag "${STABILITY_FLAG}" therefore not changing further dependencies in distribution'
+  if [[ "$STABILITY_FLAG" =~ ^(dev|alpha|beta|RC|rc)$ ]]; then
+    COMPOSER_STABILITY_FLAG=${STABILITY_FLAG}
+  else
+    COMPOSER_STABILITY_FLAG="dev"
+  fi
+  composer config minimum-stability $COMPOSER_STABILITY_FLAG
+  composer config prefer-stable true
 else
-  # Remove requirements for development version of sub dependency packages
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/fusion"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/media"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/media-browser"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/diff"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/redirecthandler"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/party"
-
-  # Remove requirements for development version of framework sub dependency packages
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/cache"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/eel"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/error-messages"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/flow"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/fluid-adaptor"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/kickstarter"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/utility-arrays"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/utility-files"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/utility-mediatypes"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/utility-objecthandling"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/utility-opcodecache"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/utility-pdo"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/utility-schema"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/utility-unicode"
-  php "${COMPOSER_PHAR}" --working-dir=Distribution remove --no-update "neos/http-factories"
+  composer config --unset prefer-stable
+  composer config --unset minimum-stability
 fi
 
 commit_manifest_update "${BRANCH}" "${BUILD_URL}" "${VERSION}" "Distribution"

--- a/Build/set-dependencies.sh
+++ b/Build/set-dependencies.sh
@@ -84,15 +84,19 @@ fi
 
 # Require main dev dependencies (from flow release)
 if [[ ${STABILITY_FLAG} ]]; then
-  php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/buildessentials:${FLOW_BRANCH}.x-dev"
+  # using alias as "stable" so neos testing helper packages can declare a dependency
+  php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/buildessentials:${FLOW_BRANCH}.x-dev as ${FLOW_BRANCH}"
+  php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/behat:${FLOW_BRANCH}.x-dev as ${FLOW_BRANCH}"
 else
   php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/buildessentials:~${FLOW_BRANCH}.0"
+  php "${COMPOSER_PHAR}" --working-dir=Distribution require --dev --no-update "neos/behat:~${FLOW_BRANCH}.0"
 fi
 
 commit_manifest_update "${BRANCH}" "${BUILD_URL}" "${VERSION}" "Distribution"
 
 php "${COMPOSER_PHAR}" --working-dir=Packages/Neos/Neos.Neos require --no-update "neos/flow:~${FLOW_BRANCH}.0"
 php "${COMPOSER_PHAR}" --working-dir=Packages/Neos/Neos.Neos require --no-update "neos/fluid-adaptor:~${FLOW_BRANCH}.0"
+php "${COMPOSER_PHAR}" --working-dir=Packages/Neos/Neos.ContentRepositoryRegistry.TestSuite require --no-update "neos/behat:~${FLOW_BRANCH}.0"
 php "${COMPOSER_PHAR}" --working-dir=Packages/Neos/Neos.SiteKickstarter require --no-update "neos/kickstarter:~${FLOW_BRANCH}.0"
 
 cd Packages/Neos || exit 1


### PR DESCRIPTION
Same philosophy as the Flow pr https://github.com/neos/flow-development-distribution/pull/93

- 2053a7a Clearly indicate that `VERSION` can be a minor level with tilde no behaviour change
- 13261e6 Require Neos.Ui in version based on the Neos branch to release
- 1511551 BUGFIX: Require `neos/site-kickstarter` as dev dependency like `neos/kickstarter` in flow base dist
- 2023e88 Bump `neos/behat` in `Neos.ContentRepositoryRegistry.TestSuite` test utility package
- 61682ae Correctly require "neos/buildessentials" dev-dependency (not doubling tilde ~ and using FLOW_BRANCH as its flow)
- 284ee48 simplify beta releases by using composer minimum stability