### PR TITLE
TASK: Add rector to the dev-dependencies 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,7 @@
     "phpunit/phpunit": "^9.6.11",
     "phpstan/phpstan": "^1.10.0",
     "squizlabs/php_codesniffer": "^3.6",
+    "rector/rector": "^1.2",
     "brianium/paratest": "^6.11",
     "neos/site-kickstarter": "9.2.x-dev"
   }


### PR DESCRIPTION
This will allow to use this tooling in github actions later ... 

- the rector version is the most recent version of rector that is compatible with our version of phpstan.

The equivalent pr for the flow-dev-dist is: https://github.com/neos/flow-development-distribution/pull/95