### PR TITLE
TASK: Require PHP-CS-Fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,7 @@
     "phpunit/phpunit": "^9.6.11",
     "phpstan/phpstan": "^1.10.0",
     "squizlabs/php_codesniffer": "^3.6",
+    "friendsofphp/php-cs-fixer": "^3.95",
     "brianium/paratest": "^6.11",
     "neos/site-kickstarter": "9.2.x-dev"
   }


### PR DESCRIPTION
This will be used by the neos and flow dev-collections The php_codesniffer dependency is left for now as it is currently used by the neos-dev-collection and can only be removed after the swich.