### PR TITLE
BUGFIX: Fix import in docker entrypoint

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,14 +6,14 @@ composer install
 ./flow doctrine:migrate
 
 # only run site import when nothing was imported before
-importedSites=`./flow site:list`
+importedSites=$(./flow site:list)
 if [ "$importedSites" = "No sites available" ]; then
     echo "Importing content from Demo"
     ./flow cr:setup
     ./flow site:importall --package-key="Neos.Demo"
 fi
 
-./flow user:create --roles Administrator $ADMIN_USERNAME $ADMIN_PASSWORD LocalDev Admin || true
+./flow user:create --roles Administrator "$ADMIN_USERNAME" "$ADMIN_PASSWORD" LocalDev Admin || true
 
 ./flow resource:publish
 ./flow flow:cache:flush

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -9,7 +9,8 @@ composer install
 importedSites=`./flow site:list`
 if [ "$importedSites" = "No sites available" ]; then
     echo "Importing content from Demo"
-    ./flow site:import --package-key="Neos.Demo"
+    ./flow cr:setup
+    ./flow site:importall --package-key="Neos.Demo"
 fi
 
 ./flow user:create --roles Administrator $ADMIN_USERNAME $ADMIN_PASSWORD LocalDev Admin || true


### PR DESCRIPTION
Hi!

I noticed the docker entrypoint has been silently broken in Neos 9 and didn't import the Neos.Demo site. This fixes it.

Thank you for having a look!