### PR TITLE
TASK: Use php8.4 in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3-cli
+FROM php:8.4-cli
 
 RUN apt-get update \
     # install GraphicsMagick


### PR DESCRIPTION
Hi!

Currently Neos 9.2 is not installable with php8.3.

See https://github.com/neos/flow-development-collection/pull/3564